### PR TITLE
Allow ES6 features and modules in eslint

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -2,7 +2,8 @@
   // ECMAScript 6 features to enable.
   "ecmaFeatures": {
     "jsx": true,
-    "modules": true
+    "modules": true,
+    "experimentalObjectRestSpread": true,
   },
 
   // Global variables to recognize.

--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -44,7 +44,6 @@
     "no-invalid-regexp": 2,                                       // Disallow invalid regular expressions (error).
     "no-mixed-spaces-and-tabs": 2,                                // Disallow mixed spaces and tabs (error).
     "no-redeclare": 2,                                            // Disallow redeclaration of variables (error).
-    "no-reserved-keys": 2,                                        // Disallow use of reserved words as object keys (can cause minification to blow up) (error).
     "no-self-compare": 1,                                         // Disallow comparison to oneself (usually a typo) (warning).
     "no-shadow-restricted-names": 2,                              // Disallow shadowing of restricted names like `arguments` (error).
     "no-trailing-spaces": 2,                                      // Disallows trailing whitespace (error).
@@ -58,6 +57,7 @@
     "one-var": [2, "never"],                                      // Enforces separate `var` for each declaration (http://eslint.org/docs/rules/one-var) (error).
     "operator-assignment": [2, "always"],                         // Enforces operator assignment where possible (e.g. `foo *= 2` instead of `foo = foo * 2`) (error).
     "quotes": [2, "single"],                                      // Always requires single quotes for strings (error).
+    "quote-props": [2, "as-needed", { "keywords": true }],        // Requires quotes for keywords and when needed. Unnecessary quotes will cause warnings.
     "radix": 2,                                                   // Requires use of radix parameter in `parseInt()` (error).
     "react/jsx-uses-react": 1,                                    // Prevent React to be incorrectly marked as unused
     "react/react-in-jsx-scope": 2,                                // Prevent missing React when using JSX

--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -1,14 +1,16 @@
 {
   // ECMAScript 6 features to enable.
   "ecmaFeatures": {
-    "jsx": true
+    "jsx": true,
+    "modules": true
   },
 
   // Global variables to recognize.
   "env": {
     "browser": true,
     "jasmine": true,
-    "node": true
+    "node": true,
+    "es6": true
   },
 
   // Style and correctness rules to enforce.
@@ -57,6 +59,8 @@
     "operator-assignment": [2, "always"],                         // Enforces operator assignment where possible (e.g. `foo *= 2` instead of `foo = foo * 2`) (error).
     "quotes": [2, "single"],                                      // Always requires single quotes for strings (error).
     "radix": 2,                                                   // Requires use of radix parameter in `parseInt()` (error).
+    "react/jsx-uses-react": 1,                                    // Prevent React to be incorrectly marked as unused
+    "react/react-in-jsx-scope": 2,                                // Prevent missing React when using JSX
     "semi": [2, "always"],                                        // Always requires semicolons (instead of depending on ASI) (error).
     "semi-spacing": [2, { "before": false, "after": true }],      // Enforces no spaces before semicolons and spacing after (http://eslint.org/docs/rules/semi-spacing) (error).
     "sort-vars": [1, { "ignoreCase": true }],                     // Requires var declarations be sorted alphabetically, case-insensitive (warning).


### PR DESCRIPTION
React Native heavily relies on ES6+/ES2015 features like arrow functions, spread operator and variable expansion. More than 80% of the react community already use ES6+ via Babel according to [a recent survey](https://angularclass.com/react-developer-survey-results/), for React Native that number would be somewhere near 100%. 

![](https://cloud.githubusercontent.com/assets/1016365/12031525/cc1ad434-adc1-11e5-8ce9-20d9fb411133.jpg)

This PR in summary:
- adds support for using ES6+ features including modules and spread operator for arrays and objects.
- fixes errors around the `React` variable and JSX
- replaces the now removed `no-reserved-keys` rule with `quote-props`.

Also, consider merging the #es6 branch. 
